### PR TITLE
Add Spring Telegram notification service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# telegramNotificationBot
+# Telegram Notification Service
+
+Сервис для отправки уведомлений в Telegram и получения обратных сообщений. Реализован на базе Spring Boot и библиотеки `org.telegram.telegrambots`.
+
+## Запуск
+
+Перед запуском необходимо указать данные бота в переменных окружения:
+
+```bash
+export TELEGRAM_BOT_USERNAME=your_bot_username
+export TELEGRAM_BOT_TOKEN=your_bot_token
+export TELEGRAM_CHAT_ID=your_chat_id
+```
+
+После чего приложение можно запустить командой:
+
+```bash
+mvn spring-boot:run
+```
+
+Сервис предоставляет HTTP‑endpoint `POST /api/notify`, принимающий текст уведомления в теле запроса и отправляющий его в Telegram.
+
+Полученные от пользователя сообщения бот повторяет в качестве ответа.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>telegram-notification-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>telegram-notification-service</name>
+    <description>Telegram notification service</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.telegram</groupId>
+            <artifactId>telegrambots-spring-boot-starter</artifactId>
+            <version>6.8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/telegram/TelegramNotificationServiceApplication.java
+++ b/src/main/java/com/example/telegram/TelegramNotificationServiceApplication.java
@@ -1,0 +1,11 @@
+package com.example.telegram;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TelegramNotificationServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(TelegramNotificationServiceApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/telegram/bot/NotificationBot.java
+++ b/src/main/java/com/example/telegram/bot/NotificationBot.java
@@ -1,0 +1,60 @@
+package com.example.telegram.bot;
+
+import com.example.telegram.config.BotConfig;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.bots.TelegramLongPollingBot;
+import org.telegram.telegrambots.meta.TelegramBotsApi;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.updatesreceivers.DefaultBotSession;
+
+@Component
+public class NotificationBot extends TelegramLongPollingBot {
+
+    private static final Logger logger = LoggerFactory.getLogger(NotificationBot.class);
+    private final BotConfig config;
+
+    public NotificationBot(BotConfig config) {
+        this.config = config;
+    }
+
+    @PostConstruct
+    public void register() throws TelegramApiException {
+        TelegramBotsApi botsApi = new TelegramBotsApi(DefaultBotSession.class);
+        botsApi.registerBot(this);
+    }
+
+    @Override
+    public String getBotUsername() {
+        return config.getUsername();
+    }
+
+    @Override
+    public String getBotToken() {
+        return config.getToken();
+    }
+
+    @Override
+    public void onUpdateReceived(Update update) {
+        if (update.hasMessage() && update.getMessage().hasText()) {
+            String chatId = update.getMessage().getChatId().toString();
+            String text = update.getMessage().getText();
+
+            SendMessage response = new SendMessage(chatId, "Вы написали: " + text);
+            try {
+                execute(response);
+            } catch (TelegramApiException e) {
+                logger.error("Failed to send message", e);
+            }
+        }
+    }
+
+    public void sendMessage(String chatId, String text) throws TelegramApiException {
+        SendMessage message = new SendMessage(chatId, text);
+        execute(message);
+    }
+}

--- a/src/main/java/com/example/telegram/config/BotConfig.java
+++ b/src/main/java/com/example/telegram/config/BotConfig.java
@@ -1,0 +1,36 @@
+package com.example.telegram.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "telegram.bot")
+public class BotConfig {
+    private String username;
+    private String token;
+    private String chatId;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getChatId() {
+        return chatId;
+    }
+
+    public void setChatId(String chatId) {
+        this.chatId = chatId;
+    }
+}

--- a/src/main/java/com/example/telegram/controller/NotificationController.java
+++ b/src/main/java/com/example/telegram/controller/NotificationController.java
@@ -1,0 +1,25 @@
+package com.example.telegram.controller;
+
+import com.example.telegram.service.NotificationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notify")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> sendNotification(@RequestBody String message) {
+        notificationService.sendNotification(message);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/telegram/service/NotificationService.java
+++ b/src/main/java/com/example/telegram/service/NotificationService.java
@@ -1,0 +1,30 @@
+package com.example.telegram.service;
+
+import com.example.telegram.bot.NotificationBot;
+import com.example.telegram.config.BotConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+@Service
+public class NotificationService {
+
+    private static final Logger logger = LoggerFactory.getLogger(NotificationService.class);
+
+    private final NotificationBot bot;
+    private final BotConfig config;
+
+    public NotificationService(NotificationBot bot, BotConfig config) {
+        this.bot = bot;
+        this.config = config;
+    }
+
+    public void sendNotification(String text) {
+        try {
+            bot.sendMessage(config.getChatId(), text);
+        } catch (TelegramApiException e) {
+            logger.error("Unable to send notification", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+telegram:
+  bot:
+    username: ${TELEGRAM_BOT_USERNAME}
+    token: ${TELEGRAM_BOT_TOKEN}
+    chat-id: ${TELEGRAM_CHAT_ID}


### PR DESCRIPTION
## Summary
- initialize Maven project for a Telegram notification service
- implement Telegram bot for sending/receiving messages
- add REST controller and service to send notifications
- document setup and usage in README

## Testing
- `mvn -q test` *(fails: `mvn` not found)*